### PR TITLE
Wrap match to check url type as string

### DIFF
--- a/typekit-cache.js
+++ b/typekit-cache.js
@@ -20,35 +20,35 @@
 
 	setAttribute = proto.setAttribute;
 	proto.setAttribute = function( name, url, /* min */ xhr, css ) {
-
-		if ( url.match( pattern ) ) {
-
-			// Get the CSS of the URL via XHR and cache it.
-			// Only overwrite cache if CSS has changed.
-
-			xhr = new XMLHttpRequest();
-			xhr.open( 'GET', url, true );
-			xhr.onreadystatechange = function() {
-
-				if ( xhr.readyState === 4 ) {
-
-					css = xhr.responseText;
-					if ( css !== cached ) storage[ key ] = css;
-
-				}
-
-			};
-			xhr.send( null );
-
-			// Reset Element.prototype.setAttribute.
-			// If the cache was empty, set the href normally.
-			// Otherwise, cancel setting the href.
-
-			proto.setAttribute = setAttribute;
-			if ( cached ) return;
-
+		if( typeof url === 'string'){
+			if ( url.match( pattern ) ) {
+	
+				// Get the CSS of the URL via XHR and cache it.
+				// Only overwrite cache if CSS has changed.
+	
+				xhr = new XMLHttpRequest();
+				xhr.open( 'GET', url, true );
+				xhr.onreadystatechange = function() {
+	
+					if ( xhr.readyState === 4 ) {
+	
+						css = xhr.responseText;
+						if ( css !== cached ) storage[ key ] = css;
+	
+					}
+	
+				};
+				xhr.send( null );
+	
+				// Reset Element.prototype.setAttribute.
+				// If the cache was empty, set the href normally.
+				// Otherwise, cancel setting the href.
+	
+				proto.setAttribute = setAttribute;
+				if ( cached ) return;
+	
+			}
 		}
-
 		setAttribute.apply( this, arguments );
 
 	};


### PR DESCRIPTION
Check `url` to make sure it is a string before testing `match`. I ran into an issue where an attribute was set to `0` and this broke because integers don't have a `match` method.

Thanks for writing this! Typekit FOUT is driving me nuts.
