### PR TITLE
Adding npm script for minification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -50,8 +50,14 @@ html:not(.wf-active):not(.wf-inactive):not(.wf-cached) * {
 }
 ```
 
-The minified version is built using `uglifyjs typekit-cache.js -o typekit-cache.min.js --compress --mangle`.
+## Contributing
 
+The minified version is built using uglifyjs which is installed as a local dependency. To install and build run the following commands:
+
+```
+$ npm install
+$ npm run prepublish
+```
 
 ## Contributors
 
@@ -60,6 +66,7 @@ The minified version is built using `uglifyjs typekit-cache.js -o typekit-cache.
 - [Michael Baldry](https://github.com/brightbits)
 - [Jan Persoons](https://github.com/janpersoons)
 - [Tristan Koch](https://github.com/trkoch)
+- [Luke Bussey](https://github.com/lukebussey)
 
 Thanks!
 

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "typekit-cache",
+  "description": "Keeps a site's Typekit in localStorage and injects it on page load. Eliminates the annoying Flash Of Invisible/Unstyled Text (FOUT) and provides better UX for slow or offline connections.",
+  "main": "typekit-cache.js",
+  "authors": [
+    "Morris Brodersen <mb@morrisbrodersen.de>"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "typekit"
+  ],
+  "homepage": "https://github.com/morris/typekit-cache",
+  "moduleType": [],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "typekit-cache",
+  "version": "1.4.1",
+  "description": "Keeps a site's Typekit in localStorage and injects it on page load. Eliminates the annoying Flash Of Invisible/Unstyled Text (FOUT) and provides better UX for slow or offline connections.",
+  "main": "typekit-cache.js",
+  "directories": {
+    "test": "test"
+  },
+  "dependencies": {
+    "uglifyjs": "^2.4.10"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepublish": "uglifyjs typekit-cache.js -o typekit-cache.min.js --compress --mangle"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morris/typekit-cache.git"
+  },
+  "keywords": [
+    "typekit"
+  ],
+  "author": "Morris Brodersen <mb@morrisbrodersen.de>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/morris/typekit-cache/issues"
+  },
+  "homepage": "https://github.com/morris/typekit-cache#readme"
+}


### PR DESCRIPTION
This PR adds `uglifyjs` as a local node module so that the minified version can be built with the npm script `npm run prepublish`.
